### PR TITLE
README: Fix Spelling Error

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ struct anony
 ```cpp
 auto constexpr t = delete_struct<"one">( s );
 // or
-auto constexpr t = s.detroy<"one">();
+auto constexpr t = s.destroy<"one">();
 ```
 
 This will delete the field 'one' in the meta-structure, and returns a meta-structure without this field.


### PR DESCRIPTION
There was an error with compiling on of the code snippets because it was trying to access the data member: `detroy()` when there is not such thing, what was meant to happen was to call `destroy()`.